### PR TITLE
Update client

### DIFF
--- a/prototypes/client/bundlepreload.js
+++ b/prototypes/client/bundlepreload.js
@@ -1,8 +1,9 @@
-function waitUntilInstalled(registration) {
+// Waits until the service worker has been activated.
+function waitUntilActivated(registration) {
     return new Promise(function (resolve, reject) {
         if (registration.installing) {
             registration.installing.addEventListener('statechange', function (e) {
-                if (e.target.state == 'installed') {
+                if (e.target.state == 'activated') {
                     resolve();
                 } else if (e.target.state == 'redundant') {
                     reject();
@@ -14,10 +15,9 @@ function waitUntilInstalled(registration) {
     });
 }
 
-function onInstalled() {
-    console.log("Service worker installed.");
-
-    // Preload the resources listed in <script type="bundlepreload">.
+// Once the service worker has been activated,
+// preload the resources listed in <script type="bundlepreload"> tags.
+function onActivated() {
     let scripts = document.getElementsByTagName("script");
     for (let script of scripts) {
         if (script.type === 'bundlepreload') {
@@ -49,8 +49,8 @@ if ('serviceWorker' in navigator) {
 
     // Register up the service worker that will carry out bundle preloading.
     navigator.serviceWorker.register('./service-worker-browserified.js', { scope: './' })
-        .then(waitUntilInstalled)
-        .then(onInstalled)
+        .then(waitUntilActivated)
+        .then(onActivated)
         .catch(function (error) {
             console.log(error);
         });

--- a/prototypes/client/service-worker.js
+++ b/prototypes/client/service-worker.js
@@ -79,7 +79,14 @@ self.addEventListener('message', function (event) {
                             headers['bundle-preload'] = resources.join(' ');
                         } else {
                             console.log('all the resources were already in cache, we are done');
-                            return;
+                            return self.clients.matchAll().then((clients) => {
+                                clients.forEach((client) => {
+                                    client.postMessage({
+                                        type: "bundlepreload-finished",
+                                        url: event.data.source
+                                    });
+                                });
+                            });
                         }
                     }
                     // else we will fetch the whole bundle
@@ -120,7 +127,7 @@ self.addEventListener('message', function (event) {
             break;
         // do nothing
         default:
-            console.log('message: unknown command');
+            console.log(`message: unknown command ${event.data.command}`);
     }
 });
 


### PR DESCRIPTION
The Service Worker sends a `bundlepreload-finished` message when the request to preload did not actually result in a bundle being fetched because all of the resources where already in cache.

The Service Worker needs to wait until it is `activated` (not `installed`) so it is able take control over the page without waiting for a reload.