### PR TITLE
Fix bundled stylesheet loading failure in subresource_loading example.

### DIFF
--- a/prototypes/examples/chromium-web-bundles-test/subresource_loading/index.html.mustache
+++ b/prototypes/examples/chromium-web-bundles-test/subresource_loading/index.html.mustache
@@ -1,22 +1,4 @@
 <!DOCTYPE html>
-<link rel="stylesheet" href="by_resource/blue_subresource_loading.css">
-<link rel="stylesheet" href="by_resource/red_subresource_loading.css">
-<link rel="stylesheet" href="by_bundle_file/green_subresource_loading.css">
-<link rel="stylesheet" href="by_bundle_file/purple_subresource_loading.css">
-<link rel="stylesheet" href="by_scope/orange_subresource_loading.css">
-<link rel="stylesheet" href="by_scope/pink_subresource_loading.css">
-<style>
-div {
-  background-color: grey;
-  width: 30px;
-  height: 30px;
-}
-img {
-  width: 30px;
-  height: 30px;
-}
-</style>
-
 <script type="webbundle">
 {
     "source": "by_resource.wbn",
@@ -28,7 +10,6 @@ img {
     ]
 }
 </script>
-
 <script type="webbundle">
     {
         "source": "by_bundle_file.wbn",
@@ -40,7 +21,6 @@ img {
         ]
     }
 </script>
-
 <script type="webbundle">
     {
         "source": "by_scope.wbn",
@@ -49,7 +29,6 @@ img {
         ]
     }
 </script>
-
 <script type="webbundle">
     {
         "source": "uuid_in_package_by_resource.wbn",
@@ -58,7 +37,6 @@ img {
         ]
     }
 </script>
-
 <script type="webbundle">
     {
         "source": "uuid_in_package_by_scope.wbn",
@@ -67,6 +45,25 @@ img {
         ]
     }
 </script>
+
+<link rel="stylesheet" href="by_resource/blue_subresource_loading.css">
+<link rel="stylesheet" href="by_resource/red_subresource_loading.css">
+<link rel="stylesheet" href="by_bundle_file/green_subresource_loading.css">
+<link rel="stylesheet" href="by_bundle_file/purple_subresource_loading.css">
+<link rel="stylesheet" href="by_scope/orange_subresource_loading.css">
+<link rel="stylesheet" href="by_scope/pink_subresource_loading.css">
+
+<style>
+div {
+  background-color: grey;
+  width: 30px;
+  height: 30px;
+}
+img {
+  width: 30px;
+  height: 30px;
+}
+</style>
 
 <h3>Chromium Web bundles test</h3>
 

--- a/prototypes/examples/chromium-web-bundles-test/subresource_loading/uuid_in_package_by_resource/index.html.mustache
+++ b/prototypes/examples/chromium-web-bundles-test/subresource_loading/uuid_in_package_by_resource/index.html.mustache
@@ -1,5 +1,17 @@
 <!DOCTYPE html>
 <html>
+ <script type="webbundle">
+     {
+         "source": "{{{baseUrl}}}/uuid_in_package_by_resource.wbn",
+         "resources": [
+             "{{{baseUrl}}}/uuid_in_package_by_resource/skyblue_subresource_loading.css",
+             "{{{baseUrl}}}/uuid_in_package_by_resource/skyblue_subresource_loading.png",
+             "{{{baseUrl}}}/uuid_in_package_by_resource/yellowgreen_subresource_loading.css",
+             "{{{baseUrl}}}/uuid_in_package_by_resource/yellowgreen_subresource_loading.png"
+         ]
+     }
+ </script>
+
  <link rel="stylesheet" href="{{{baseUrl}}}/uuid_in_package_by_resource/skyblue_subresource_loading.css">
  <link rel="stylesheet" href="{{{baseUrl}}}/uuid_in_package_by_resource/yellowgreen_subresource_loading.css">
  <style>
@@ -13,18 +25,6 @@
      height: 30px;
    }
  </style>
-
- <script type="webbundle">
-     {
-         "source": "{{{baseUrl}}}/uuid_in_package_by_resource.wbn",
-         "resources": [
-             "{{{baseUrl}}}/uuid_in_package_by_resource/skyblue_subresource_loading.css",
-             "{{{baseUrl}}}/uuid_in_package_by_resource/skyblue_subresource_loading.png",
-             "{{{baseUrl}}}/uuid_in_package_by_resource/yellowgreen_subresource_loading.css",
-             "{{{baseUrl}}}/uuid_in_package_by_resource/yellowgreen_subresource_loading.png"
-         ]
-     }
- </script>
 
  <h4>Identified by resource inside opaque origin iframe</h4>
 

--- a/prototypes/examples/chromium-web-bundles-test/subresource_loading/uuid_in_package_by_scope/index.html.mustache
+++ b/prototypes/examples/chromium-web-bundles-test/subresource_loading/uuid_in_package_by_scope/index.html.mustache
@@ -1,5 +1,14 @@
 <!DOCTYPE html>
 <html>
+ <script type="webbundle">
+     {
+         "source": "{{{baseUrl}}}/uuid_in_package_by_scope.wbn",
+         "scopes": [
+             "{{{baseUrl}}}/uuid_in_package_by_scope"
+         ]
+     }
+ </script>
+
  <link rel="stylesheet" href="{{{baseUrl}}}/uuid_in_package_by_scope/navy_subresource_loading.css">
  <link rel="stylesheet" href="{{{baseUrl}}}/uuid_in_package_by_scope/orangered_subresource_loading.css">
  <style>
@@ -13,15 +22,6 @@
      height: 30px;
    }
  </style>
-
- <script type="webbundle">
-     {
-         "source": "{{{baseUrl}}}/uuid_in_package_by_scope.wbn",
-         "scopes": [
-             "{{{baseUrl}}}/uuid_in_package_by_scope"
-         ]
-     }
- </script>
 
  <h4>Identified by scope inside opaque origin iframe</h4>
 


### PR DESCRIPTION
Prepare script elements for WebBundle before link elements for stylesheet.